### PR TITLE
Fix typing for self-reference in Character class

### DIFF
--- a/main/character.py
+++ b/main/character.py
@@ -12,7 +12,7 @@ class Character:
         self.rect = self.image.get_rect()
         self.rect.center = (x, y)
 
-    def attack(self, target: Character):
+    def attack(self, target: 'Character'):
         damage = max(0, self.strength - target.defense)
 
         target.get_damage(damage)


### PR DESCRIPTION
There is a problem with type hints in body of a class that points to the actual class. I made a fix and here is some docs that explains this:
![image](https://user-images.githubusercontent.com/81487161/232306052-dcbb7e6a-5d69-4e5b-90c4-0fe0f8e35b60.png)
link to full doc below:
https://peps.python.org/pep-0484/#forward-references