### PR TITLE
Exp gain method in player

### DIFF
--- a/main/config.ini
+++ b/main/config.ini
@@ -11,3 +11,14 @@ red = #FF0000
 green = #00FF00
 white = #FFFFFF
 orange = #F1A41D
+
+[Player Settings]
+#Player parameters:
+starting_exp_needed_for_next_level = 100
+starting_attribute_points = 10
+starting_money = 0
+backpack_size = 12
+
+#Player's "level_up" method attributes:
+exp_needed_multiplier = 1.2
+added_max_hp = 10

--- a/main/config.ini
+++ b/main/config.ini
@@ -14,6 +14,8 @@ orange = #F1A41D
 
 [Player Settings]
 #Player parameters:
+starting_level = 0
+starting_experience = 0
 starting_exp_needed_for_next_level = 100
 starting_attribute_points = 10
 starting_money = 0
@@ -21,4 +23,4 @@ backpack_size = 12
 
 #Player's "level_up" method attributes:
 exp_needed_multiplier = 1.2
-added_max_hp = 10
+max_hp_added = 10

--- a/main/player.py
+++ b/main/player.py
@@ -4,7 +4,7 @@ from character import Character
 
 
 class Player(Character):
-    def __init__(self, x, y, name: str, strength: int, defense: int, health_points: int):
+    def __init__(self, x: int, y: int, name: str, strength: int, defense: int, health_points: int):
         super().__init__(x, y, name, strength, defense, health_points)
         self.backpack: list = []
         self.backpack_size: int = 12

--- a/main/player.py
+++ b/main/player.py
@@ -7,7 +7,7 @@ class Player(Character):
     def __init__(self, x, y, name, strength, defense, health_points):
         super().__init__(x, y, name, strength, defense, health_points)
         self.backpack = []
-        self.backpack_size = 4
+        self.backpack_size = 12
         self.level = 1
         self.experience = 0
         self.experience_needed = 100
@@ -23,13 +23,6 @@ class Player(Character):
     def remove_from_backpack(self, item):
         if item in self.backpack:
             self.backpack.remove(item)
-            print(f"{item} removed from backpack")
-        else:
-            print(f"{item} not found in backpack")
-
-    def expand_backpack(self):
-        self.backpack_size += 1
-        print(f"Backpack size has increased to {self.backpack_size}")
 
     def gain_experience(self, sum_of_enemys_stats):
         self.experience += sum_of_enemys_stats

--- a/main/player.py
+++ b/main/player.py
@@ -2,25 +2,29 @@ import pygame
 
 from character import Character
 
+import configparser
+config = configparser.ConfigParser()
+config.read("config.ini")
+
 
 class Player(Character):
     def __init__(self, x: int, y: int, name: str, strength: int, defense: int, health_points: int):
         super().__init__(x, y, name, strength, defense, health_points)
+        self.level: int = config.getint("Player Settings", "starting_level")
+        self.experience: int = config.getint("Player Settings", "starting_experience")
+        self.experience_needed: int = config.getint("Player Settings", "starting_exp_needed_for_next_level")
+        self.attribiute_points: int = config.getint("Player Settings", "starting_attribute_points")
+        self.money: int = config.getint("Player Settings", "starting_money")
         self.backpack: list = []
-        self.backpack_size: int = 12
-        self.level: int = 1
-        self.experience: int = 0
-        self.experience_needed: int = 100
-        self.attribiute_points: int = 10
-        self.money: int = 0
+        self.backpack_size: int = config.getint("Player Settings", "backpack_size")
 
-    def add_to_backpack(self, item):
+    def add_to_backpack(self, item) -> None:
         if len(self.backpack) < self.backpack_size:
             self.backpack.append(item)
         else:
             print("Backpack is full")
 
-    def remove_from_backpack(self, item):
+    def remove_from_backpack(self, item) -> None:
         if item in self.backpack:
             self.backpack.remove(item)
 
@@ -30,8 +34,8 @@ class Player(Character):
             self.experience -= self.experience_needed
             self.level_up()
 
-    def level_up(self):
+    def level_up(self) -> None:
         self.level += 1
-        self.experience_needed = int(self.experience_needed * 1.2)
-        self.health_points_max += 10
+        self.experience_needed *= config.getint("Player Settings", "exp_needed_multiplier")
+        self.health_points_max += config.getint("Player Settings", "max_hp_added")
         self.health_points = self.health_points_max

--- a/main/player.py
+++ b/main/player.py
@@ -9,7 +9,7 @@ class Player(Character):
         self.backpack = []
         self.backpack_size = 4
         self.level = 1
-        self.experience = 1
+        self.experience = 0
         self.experience_needed = 100
         self.attribiute_points = 10
         self.money = 0
@@ -33,14 +33,14 @@ class Player(Character):
 
     def gain_experience(self, sum_of_enemys_stats):
         self.experience += sum_of_enemys_stats
-        if self.experience >= self.experience_needed:
+        while self.experience >= self.experience_needed:
             self.experience -= self.experience_needed
             self.level_up()
 
     def level_up(self):
         self.level += 1
         self.experience_needed = int(self.experience_needed * 1.2)
-        self.strength += 1
-        self.defense += 1
+        self.strength += 2
+        self.defense += 2
         self.health_points_max += 10
         self.health_points = self.health_points_max

--- a/main/player.py
+++ b/main/player.py
@@ -4,15 +4,15 @@ from character import Character
 
 
 class Player(Character):
-    def __init__(self, x, y, name, strength, defense, health_points):
+    def __init__(self, x, y, name: str, strength: int, defense: int, health_points: int):
         super().__init__(x, y, name, strength, defense, health_points)
-        self.backpack = []
-        self.backpack_size = 12
-        self.level = 1
-        self.experience = 0
-        self.experience_needed = 100
-        self.attribiute_points = 10
-        self.money = 0
+        self.backpack: list = []
+        self.backpack_size: int = 12
+        self.level: int = 1
+        self.experience: int = 0
+        self.experience_needed: int = 100
+        self.attribiute_points: int = 10
+        self.money: int = 0
 
     def add_to_backpack(self, item):
         if len(self.backpack) < self.backpack_size:
@@ -24,7 +24,7 @@ class Player(Character):
         if item in self.backpack:
             self.backpack.remove(item)
 
-    def gain_experience(self, sum_of_enemys_stats):
+    def gain_experience(self, sum_of_enemys_stats: int) -> None:
         self.experience += sum_of_enemys_stats
         while self.experience >= self.experience_needed:
             self.experience -= self.experience_needed
@@ -33,7 +33,5 @@ class Player(Character):
     def level_up(self):
         self.level += 1
         self.experience_needed = int(self.experience_needed * 1.2)
-        self.strength += 2
-        self.defense += 2
         self.health_points_max += 10
         self.health_points = self.health_points_max

--- a/main/player.py
+++ b/main/player.py
@@ -1,4 +1,5 @@
 import pygame
+
 from character import Character
 
 
@@ -8,7 +9,7 @@ class Player(Character):
         self.backpack = []
         self.backpack_size = 4
         self.level = 1
-        self.experience = 0
+        self.experience = 1
         self.experience_needed = 100
         self.attribiute_points = 10
         self.money = 0
@@ -30,12 +31,16 @@ class Player(Character):
         self.backpack_size += 1
         print(f"Backpack size has increased to {self.backpack_size}")
 
-    def gain_experience(self, gained_experience):
-        self.experience += gained_experience
+    def gain_experience(self, sum_of_enemys_stats):
+        self.experience += sum_of_enemys_stats
         if self.experience >= self.experience_needed:
+            self.experience -= self.experience_needed
             self.level_up()
 
     def level_up(self):
         self.level += 1
         self.experience_needed = int(self.experience_needed * 1.2)
-        print(f"Your actual level: {self.level}")
+        self.strength += 1
+        self.defense += 1
+        self.health_points_max += 10
+        self.health_points = self.health_points_max


### PR DESCRIPTION
- Reworking gain_experience method to while loop, so player can gain more than 1 lvl when xp points  gained > xp needed for more than 1 lvl. Also adding assignment statement that transfers remaining xp points to next "experience_needed" pool.
- Cleaning some not necessary ( i thing) methods for expanding backpack and expanding  backpack slots to 12.
- Giving level_up method a way to add statistics to player and regenarate health to maximum when player is leveling up.